### PR TITLE
Add reach to size modifier

### DIFF
--- a/common/src/main/java/me/ultrusmods/sizeshiftingpotions/CustomScaleTypes.java
+++ b/common/src/main/java/me/ultrusmods/sizeshiftingpotions/CustomScaleTypes.java
@@ -17,6 +17,7 @@ public class CustomScaleTypes {
     private static ScaleType registerScale(String id, ScaleModifier dependantModifier) {
         final ScaleType.Builder builder = ScaleType.Builder.create().affectsDimensions();
 
+        builder.addDependentModifier(ScaleModifiers.REACH_MULTIPLIER);
         builder.addDependentModifier(dependantModifier);
 
         return ScaleRegistries.register(ScaleRegistries.SCALE_TYPES,
@@ -32,6 +33,8 @@ public class CustomScaleTypes {
         ScaleTypes.WIDTH.getDefaultBaseValueModifiers().add(SIZE_MODIFIER);
         ScaleTypes.VISIBILITY.getDefaultBaseValueModifiers().add(SIZE_MODIFIER);
         ScaleTypes.MOTION.getDefaultBaseValueModifiers().add(SIZE_MODIFIER);
+
+        ScaleTypes.REACH.getDefaultBaseValueModifiers().add(SIZE_MODIFIER);
 
         ScaleTypes.WIDTH.getDefaultBaseValueModifiers().add(THICKNESS_MODIFIER);
     }

--- a/common/src/main/java/me/ultrusmods/sizeshiftingpotions/effects/MultiplyingSizeStatusEffect.java
+++ b/common/src/main/java/me/ultrusmods/sizeshiftingpotions/effects/MultiplyingSizeStatusEffect.java
@@ -19,12 +19,9 @@ public class MultiplyingSizeStatusEffect extends StatusEffect {
     @Override
     public void onApplied(LivingEntity entity, AttributeContainer attributes, int amplifier) {
         ScaleData scaleData = scaleType.getScaleData(entity);
-
-
         double newScale = (amplifier + 1) * SizeShiftingPotionsConfig.sizeChangeFactor;
         newScale = Math.min(newScale, SizeShiftingPotionsConfig.maxSize);
         scaleData.setTargetScale((float) newScale);
-
         scaleData.setScaleTickDelay(scaleData.getScaleTickDelay());
     }
 

--- a/common/src/main/java/me/ultrusmods/sizeshiftingpotions/effects/MultiplyingSizeStatusEffect.java
+++ b/common/src/main/java/me/ultrusmods/sizeshiftingpotions/effects/MultiplyingSizeStatusEffect.java
@@ -19,9 +19,12 @@ public class MultiplyingSizeStatusEffect extends StatusEffect {
     @Override
     public void onApplied(LivingEntity entity, AttributeContainer attributes, int amplifier) {
         ScaleData scaleData = scaleType.getScaleData(entity);
+
+
         double newScale = (amplifier + 1) * SizeShiftingPotionsConfig.sizeChangeFactor;
         newScale = Math.min(newScale, SizeShiftingPotionsConfig.maxSize);
         scaleData.setTargetScale((float) newScale);
+
         scaleData.setScaleTickDelay(scaleData.getScaleTickDelay());
     }
 


### PR DESCRIPTION
Makes the scale modifier of size also affect the reach of the player, as it normally does when setting the base scale using commands.
Fixes issue #15 

Ah if you could also put the 1.20 branch as the main one that would be great! Because I got confused when I cloned and compiled for 1.19 instead.